### PR TITLE
Fix bulk allocation and turn off static generation on landing page

### DIFF
--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -101,20 +101,20 @@ export async function getStaticProps(ctx) {
       },
     };
   } else if (process.env.SINGLE_GROUP_MODE == "true") {
-    const ssrCache = ssrExchange({ isClient: false });
-    const client = initUrqlClient(createClientConfig(ssrCache), false);
+    // const ssrCache = ssrExchange({ isClient: false });
+    // const client = initUrqlClient(createClientConfig(ssrCache), false);
 
     // This query is used to populate the cache for the query
     // used on this page.
-    await client.query(GROUP_PAGE_QUERY, { groupSlug: "c" }).toPromise();
-    await client.query(TOP_LEVEL_QUERY, { groupSlug: "c" }).toPromise();
+    // await client.query(GROUP_PAGE_QUERY, { groupSlug: "c" }).toPromise();
+    // await client.query(TOP_LEVEL_QUERY, { groupSlug: "c" }).toPromise();
 
     return {
       props: {
         // urqlState is a keyword here so withUrqlClient can pick it up.
-        urqlState: ssrCache.extractData(),
+        //urqlState: ssrCache.extractData(),
       },
-      revalidate: 60,
+      //revalidate: 60,
     };
   }
 

--- a/ui/server/graphql/resolvers/index.ts
+++ b/ui/server/graphql/resolvers/index.ts
@@ -1977,15 +1977,17 @@ const resolvers = {
           },
         });
 
-        for (const member of roundMembers) {
-          await allocateToMember({
-            member,
-            roundId: roundId,
-            amount,
-            type,
-            allocatedBy: currentCollMember.id,
-          });
-        }
+        await Promise.all(
+          roundMembers.map((member) =>
+            allocateToMember({
+              member,
+              roundId,
+              amount,
+              type,
+              allocatedBy: currentCollMember.id,
+            })
+          )
+        );
 
         return roundMembers;
       }


### PR DESCRIPTION
Fixes two issues:
- bulk allocation to thousands of members caused the vercel function to timeout, this fix will do the allocation in parallell instead of iterating through and awaiting responses in turn
- static generation on the landing page currently has some issues, not displaying archived rounds for admins, turning that off for now